### PR TITLE
chore(renovate): add PR creation filters for minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
     "helpers:pinGitHubActionDigests"
   ],
   "minimumReleaseAge": "3 days",
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Add prCreation="not-pending" and internalChecksFilter="strict" to ensure branches and PRs are only created after the 3-day minimum release age has passed, rather than creating them immediately.