### PR TITLE
feat(deps): support guzzlehttp/psr7 v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.2",
         "jms/serializer": "^3.1",
-        "guzzlehttp/psr7": "^2.0"
+        "guzzlehttp/psr7": "^2.0 || ^3.0"
     },
     "require-dev": {
         "ext-json": "*",


### PR DESCRIPTION
Widen the constraint to `^2.0 || ^3.0`. UriHandler only constructs
`GuzzleHttp\Psr7\Uri` from a string and casts it back, which is unchanged
in v3, so no source changes are needed.

This unblocks downstream packages that want to move to psr7 v3 or
guzzle v8.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FFe9xMU2GNZmCxT9BGQzxx