### PR TITLE
ci: unblock renovate automerge and pin actions to exact release tags

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,7 +13,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.10/scripts/download-actionlint.bash) 1.7.9

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,7 +12,7 @@ jobs:
   commits:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
       - uses: webiny/action-conventional-commits@8bc41ff4e7d423d56fa4905f6ff79209a78776c7 # v1.3.0
@@ -22,7 +22,7 @@ jobs:
   pr-title:
     runs-on: ubuntu-24.04
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -13,5 +13,5 @@ jobs:
   validate:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: suzuki-shunsuke/github-action-renovate-config-validator@ca480cb7ec89a9e1cd8c214ad33bda1617184027 # v2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: ${{ matrix.php }}
           extensions: json
@@ -33,7 +33,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: test-results-php-${{ matrix.php }}
           path: build/logs/
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: '8.2'
           tools: composer:v2
@@ -75,7 +75,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,8 @@
     "helpers:pinGitHubActionDigests"
   ],
   "minimumReleaseAge": "3 days",
-  "prCreation": "not-pending",
   "internalChecksFilter": "strict",
+  "automerge": true,
   "customManagers": [
     {
       "customType": "regex",
@@ -23,12 +23,11 @@
   ],
   "packageRules": [
     {
+      "description": "Never automerge a bare hash bump. Actions are pinned to an exact release tag, so a digest-only update means that tag was moved to point at different code - that needs a human to look at it.",
       "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "major"
+        "digest"
       ],
-      "automerge": true
+      "automerge": false
     },
     {
       "matchCurrentVersion": "8.0",


### PR DESCRIPTION
Renovate has not opened a PR since March. `prCreation: "not-pending"` waits for a green branch status, but no workflow triggers on a plain branch push (CI runs on `pull_request` and `push` to main only), so the only status on a renovate branch is its own `renovate/stability-days` check. Renovate treats a branch whose sole successful checks are internal as pending, and the `prNotPendingHours` escape hatch is skipped whenever the stability status is green - so the branches sat in AwaitingTests forever. Ten of them then filled the branch concurrency limit of 10, which is why the dependency dashboard listed further updates as rate-limited with zero open PRs.

`internalChecksFilter: "strict"` already withholds updates until they meet `minimumReleaseAge`, so dropping `prCreation` loses no safety: a PR still cannot appear until the release is 3 days old, and automerge still waits for real CI on the PR.

- Drop `prCreation: "not-pending"`.
- Move `automerge` to the top level so every update type is covered, majors included, replacing the minor/patch/major rule.
- Refuse automerge on digest-only updates. Actions are pinned to an exact release tag, so a bare hash bump means that tag was moved to point at different code, which needs review.
- Comment each action pin with the release tag its hash actually resolves to, rather than a floating major. The hashes are unchanged - `actions/checkout@8e8c483` was already v6.0.1, not the v6 the comment claimed - so CI runs exactly the same code, and renovate can now offer real version upgrades instead of opaque digest bumps.


Claude-Session: https://claude.ai/code/session_018o1voBtaRjMAvkJWkmUyrY