### PR TITLE
ci: exclude chore commits from release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,20 @@
     "bump-minor-pre-major": false,
     "bump-patch-for-minor-pre-major": false,
     "draft": false,
-    "prerelease": false
+    "prerelease": false,
+    "changelog-sections": [
+      { "type": "feat", "section": "Features" },
+      { "type": "fix", "section": "Bug Fixes" },
+      { "type": "perf", "section": "Performance Improvements" },
+      { "type": "deps", "section": "Dependencies" },
+      { "type": "revert", "section": "Reverts" },
+      { "type": "docs", "section": "Documentation" },
+      { "type": "style", "section": "Styles" },
+      { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+      { "type": "refactor", "section": "Code Refactoring" },
+      { "type": "test", "section": "Tests" },
+      { "type": "build", "section": "Build System" },
+      { "type": "ci", "section": "Continuous Integration" }
+    ]
   }
 }


### PR DESCRIPTION
release-please hides no commit types by default, so every Renovate `chore(deps):` commit ended up in `CHANGELOG.md` (see the 1.2.1 and 1.2.2 entries, which are nothing but chores).

This declares the full `changelog-sections` list explicitly — matching release-please's own defaults — and marks `chore` as `hidden: true`.

Note: Renovate commits here use `chore(deps):`, so dependency bumps will no longer appear in release notes at all. Releases will still be cut (any commit type bumps a patch), just with empty notes when a release contains only chores. If you'd rather keep dependency updates visible, we can have Renovate emit `deps(...)`/`fix(deps):` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpcPcYPxhTJCE37rVfX5Qz