### PR TITLE
test: replace doctrine annotations with native PHP attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "jms/serializer": "^3.1",
+        "jms/serializer": "^3.14",
         "guzzlehttp/psr7": "^2.0 || ^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     "require-dev": {
         "ext-json": "*",
         "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
-        "friendsofphp/php-cs-fixer": "3.95.18",
-        "doctrine/annotations": "^2.0.0"
+        "friendsofphp/php-cs-fixer": "3.95.18"
     },
     "autoload": {
         "psr-4": {

--- a/tests/src/Unit/UriHandlerTest.php
+++ b/tests/src/Unit/UriHandlerTest.php
@@ -96,10 +96,11 @@ XML;
 class UriDummy
 {
     /**
-     * @var Uri
+     * Deliberately untyped so the type comes only from the attribute below.
      *
-     * @Serializer\Type("GuzzleHttp\Psr7\Uri")
+     * @var Uri
      */
+    #[Serializer\Type(Uri::class)]
     private $uri;
 
     public function getUri(): Uri
@@ -121,10 +122,11 @@ class UriDummy
 class UriInterfaceDummy
 {
     /**
-     * @var UriInterface
+     * Deliberately untyped so the type comes only from the attribute below.
      *
-     * @Serializer\Type("Psr\Http\Message\UriInterface")
+     * @var UriInterface
      */
+    #[Serializer\Type(UriInterface::class)]
     private $uri;
 
     public function getUri(): UriInterface


### PR DESCRIPTION
doctrine/annotations is abandoned and was only a dev dependency, used solely by the test fixtures' @Serializer\Type docblocks. jms/serializer 3.14+ reads native PHP 8 attributes, and SerializerBuilder falls back to the AttributeDriver when no annotation reader is available, so the package can be dropped entirely.

The fixture properties stay untyped on purpose: with a declared property type, jms/serializer infers the type itself and the test would pass even if the attribute were never read.


Claude-Session: https://claude.ai/code/session_01Nxex1xWsJgmcZQZMc2pgYe